### PR TITLE
fix(core): escape backslashes in Windows file paths for Milvus queries

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -296,9 +296,11 @@ export class CodeContext {
     }
 
     private async deleteFileChunks(collectionName: string, relativePath: string): Promise<void> {
+        // Escape backslashes for Milvus query expression (Windows path compatibility)
+        const escapedPath = relativePath.replace(/\\/g, '\\\\');
         const results = await this.vectorDatabase.query(
             collectionName,
-            `relativePath == "${relativePath}"`,
+            `relativePath == "${escapedPath}"`,
             ['id']
         );
 


### PR DESCRIPTION
  ## Problem
  Sync operations fail on Windows when files are modified due to Milvus query parsing errors:

  Error: Failed to query Milvus: cannot parse expression: relativePath == "Source\New Text Document.txt",
  error: line 1:16 token recognition error at: '"Source\N': invalid parameter

  ## Root Cause
  Windows file paths use backslashes (`Source\file.txt`) which Milvus's query parser interprets as escape sequences. The `\N` in `Source\New...` triggers a parsing error.

  ## Solution
  Escape backslashes in file paths before constructing Milvus query expressions:
  ```javascript
  const escapedPath = relativePath.replace(/\\/g, '\\\\');