### PR TITLE
fix(mcp): sync operations not loading project-specific ignore patterns

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -237,6 +237,9 @@ export class CodeContext {
         const synchronizer = this.synchronizers.get(collectionName);
 
         if (!synchronizer) {
+            // Load project-specific ignore patterns before creating FileSynchronizer
+            await this.loadGitignorePatterns(codebasePath);
+            
             // To be safe, let's initialize if it's not there.
             const newSynchronizer = new FileSynchronizer(codebasePath, this.ignorePatterns);
             await newSynchronizer.initialize();

--- a/packages/mcp/src/handlers.ts
+++ b/packages/mcp/src/handlers.ts
@@ -357,7 +357,10 @@ export class ToolHandlers {
             const hash = crypto.createHash('md5').update(normalizedPath).digest('hex');
             const collectionName = `code_chunks_${hash.substring(0, 8)}`;
 
-            // Initialize file synchronizer with proper ignore patterns
+            // Load ignore patterns from files first (including .ignore, .gitignore, etc.)
+            await this.codeContext['loadGitignorePatterns'](absolutePath);
+            
+            // Initialize file synchronizer with proper ignore patterns (including project-specific patterns)
             const { FileSynchronizer } = await import("@zilliz/code-context-core");
             const ignorePatterns = this.codeContext['ignorePatterns'] || [];
             console.log(`[BACKGROUND-INDEX] Using ignore patterns: ${ignorePatterns.join(', ')}`);


### PR DESCRIPTION
  ## Problem

  Sync operations were inconsistent with initial indexing in terms of ignore pattern handling:

  - **Initial indexing**: Properly loaded project-specific patterns from `.ignore`, `.gitignore`, etc.
  - **Sync operations**: Only used default patterns, missing project-specific patterns

  This caused sync to process files that should have been ignored, leading to:
  - Performance issues during sync on large codebases
  - Incorrect indexing of files that should be excluded
  - Inconsistent behavior between initial indexing and subsequent syncs
  
  ## Solution

  Ensure both code paths consistently load project-specific ignore patterns before creating `FileSynchronizer` instances:

  1. **`reindexByChange` method**: Added `loadGitignorePatterns` call when creating new synchronizers
  2. **`startBackgroundIndexing` method**: Added `loadGitignorePatterns` call before synchronizer creation